### PR TITLE
Fix: Add missing parenthesis

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function rewiredSWC({ swcLoaderOptions } = {}) {
             test: /\.(js|mjs|jsx|ts|tsx)$/,
             include: [paths.appSrc],
             loader: require.resolve('swc-loader'),
-            options: swcLoaderOptions || useSwcConfig ? undefined : {
+            options: swcLoaderOptions || (useSwcConfig ? undefined : {
               jsc: {
                 target: 'es2015',
                 externalHelpers: true,
@@ -58,7 +58,7 @@ function rewiredSWC({ swcLoaderOptions } = {}) {
                     dynamicImport: true,
                   },
               },
-            },
+            }),
           });
         }
       }


### PR DESCRIPTION
If swcLoaderOptions was defined, options was getting set to undefined. This fixes that.